### PR TITLE
fix(pcap-filters): validate start date if end date changes and vice versa

### DIFF
--- a/metron-interface/metron-alerts/src/app/pcap/pcap-filters/pcap-filters.component.spec.ts
+++ b/metron-interface/metron-alerts/src/app/pcap/pcap-filters/pcap-filters.component.spec.ts
@@ -16,15 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { Component, Input, Output, EventEmitter, DebugElement, SimpleChange } from '@angular/core';
+import { DebugElement, SimpleChange } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { PcapFiltersComponent } from './pcap-filters.component';
 import { DatePickerModule } from '../../shared/date-picker/date-picker.module';
 import { PcapRequest } from '../model/pcap.request';
+import { DEFAULT_TIMESTAMP_FORMAT } from '../../utils/constants';
+import * as moment from 'moment/moment';
 
 describe('PcapFiltersComponent', () => {
   let component: PcapFiltersComponent;
@@ -414,5 +416,49 @@ describe('PcapFiltersComponent', () => {
       });
     });
 
+    it('start date should be valid by default', () => {
+      expect(component.filterForm.get('startTime').valid).toBe(true);
+    });
+
+    it('start date is invalid if it is bigger than end date', () => {
+      // start time is bigger than end time
+      component.filterForm.patchValue({
+        startTime: '2018-08-24 16:30:00',
+        endTime: '2018-08-23 16:30:00'
+      });
+
+      expect(component.filterForm.get('startTime').valid).toBe(false);
+    });
+
+    it('start date should be valid again based on the end date', () => {
+      // start time is bigger than end time
+      component.filterForm.patchValue({
+        startTime: '2018-08-24 16:30:00',
+        endTime: '2018-08-23 16:30:00'
+      });
+
+      expect(component.filterForm.get('startTime').valid).toBe(false);
+
+      component.filterForm.patchValue({
+        endTime: '2018-08-25 16:30:00'
+      });
+
+      expect(component.filterForm.get('startTime').valid).toBe(true);
+    });
+
+    it('end date should be valid by default', () => {
+      expect(component.filterForm.get('endTime').valid).toBe(true);
+    });
+
+    it('end date is invalid if it is in the future', () => {
+
+      expect(component.filterForm.get('endTime').valid).toBe(true);
+
+      component.filterForm.patchValue({
+        endTime: moment(new Date()).add(2, 'days').format(DEFAULT_TIMESTAMP_FORMAT)
+      });
+
+      expect(component.filterForm.get('endTime').valid).toBe(false);
+    });
   });
 });

--- a/metron-interface/metron-alerts/src/app/pcap/pcap-filters/pcap-filters.component.ts
+++ b/metron-interface/metron-alerts/src/app/pcap/pcap-filters/pcap-filters.component.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Component, Input, Output, EventEmitter, OnChanges, SimpleChanges} from '@angular/core';
+import {Component, Input, Output, EventEmitter, OnChanges, OnInit, SimpleChanges} from '@angular/core';
 import { FormGroup, FormControl, Validators, ValidationErrors } from '@angular/forms';
 
 import * as moment from 'moment/moment';
@@ -23,17 +23,27 @@ import { DEFAULT_START_TIME, DEFAULT_END_TIME, DEFAULT_TIMESTAMP_FORMAT } from '
 
 import { PcapRequest } from '../model/pcap.request';
 
-function dateRangeValidator(formControl: FormControl): ValidationErrors | null {
+function validateStartDate(formControl: FormControl): ValidationErrors | null {
   if (!formControl.parent) {
     return null;
   }
-
   const filterForm = formControl.parent;
   const startTimeMs = new Date(filterForm.controls['startTime'].value).getTime();
   const endTimeMs = new Date(filterForm.controls['endTime'].value).getTime();
+  if (startTimeMs > endTimeMs) {
+    return { error: 'Start time cannot be bigger than end date.' };
+  }
+  return null;
+}
 
-  if (startTimeMs > endTimeMs || endTimeMs > new Date().getTime()) {
-    return { error: 'Selected date range is invalid.' };
+function validateEndDate(formControl: FormControl): ValidationErrors | null {
+  if (!formControl.parent) {
+    return null;
+  }
+  const filterForm = formControl.parent;
+  const endTimeMs = new Date(filterForm.controls['endTime'].value).getTime();
+  if (endTimeMs > new Date().getTime()) {
+    return { error: 'End time cannot be in the future.' };
   }
   return null;
 }
@@ -91,7 +101,7 @@ export type PcapFilterFormValue = {
   templateUrl: './pcap-filters.component.html',
   styleUrls: ['./pcap-filters.component.scss']
 })
-export class PcapFiltersComponent implements OnChanges {
+export class PcapFiltersComponent implements OnInit, OnChanges {
 
   @Input() queryRunning = true;
   @Input() model: PcapRequest = new PcapRequest();
@@ -101,8 +111,8 @@ export class PcapFiltersComponent implements OnChanges {
   private validPort: RegExp = /^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$/;
 
   filterForm = new FormGroup({
-    startTime: new FormControl(moment(DEFAULT_START_TIME).format(DEFAULT_TIMESTAMP_FORMAT), dateRangeValidator),
-    endTime: new FormControl(moment(DEFAULT_END_TIME).format(DEFAULT_TIMESTAMP_FORMAT), dateRangeValidator),
+    startTime: new FormControl(moment(DEFAULT_START_TIME).format(DEFAULT_TIMESTAMP_FORMAT), validateStartDate),
+    endTime: new FormControl(moment(DEFAULT_END_TIME).format(DEFAULT_TIMESTAMP_FORMAT), validateEndDate),
     ipSrcAddr: new FormControl('', Validators.pattern(this.validIp)),
     ipSrcPort: new FormControl('', Validators.pattern(this.validPort)),
     ipDstAddr: new FormControl('', Validators.pattern(this.validIp)),
@@ -111,6 +121,19 @@ export class PcapFiltersComponent implements OnChanges {
     includeReverse: new FormControl(),
     packetFilter: new FormControl(''),
   });
+
+  ngOnInit() {
+    this.filterForm.get('startTime').valueChanges.subscribe((value) => {
+       this.filterForm.get('endTime').updateValueAndValidity({
+         emitEvent: false
+       });
+    });
+    this.filterForm.get('endTime').valueChanges.subscribe((value) => {
+      this.filterForm.get('startTime').updateValueAndValidity({
+        emitEvent: false
+      });
+    });
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['model']) {


### PR DESCRIPTION
## Contributor Comments

We have to validate the "other" field's value if one changes. By default, angular validates the fields when the user changes the value manually (opens the calendar and picks another date or time). But in our case, this could cause problems.

Imagine the following:
- You set the start date bigger than the end date. The start date marked in red as expected.
- You set the end date bigger than the start date. No red mark on the end date (if it is not in the future but please do not deal with it for now) field as expected, but the start date is still marked in red however it contains a valid value (an earlier date than the end date). This is it because the user has had interactions on the end date, she hasn't done anything on the start date.

Solution:
Every time the end date changes we force the start date field to be validated and vice versa.


## Pull Request Checklist

Thank you for submitting a contribution to Apache Metron.  
Please refer to our [Development Guidelines](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=61332235) for the complete guide to follow for contributions.  
Please refer also to our [Build Verification Guidelines](https://cwiki.apache.org/confluence/display/METRON/Verifying+Builds?show-miniview) for complete smoke testing guides.  


In order to streamline the review of the contribution we ask you follow these guidelines and ask you to double check the following:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? If not one needs to be created at [Metron Jira](https://issues.apache.org/jira/browse/METRON/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel).
- [ ] Does your PR title start with METRON-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.
- [ ] Has your PR been rebased against the latest commit within the target branch (typically master)?


### For code changes:
- [ ] Have you included steps to reproduce the behavior or problem that is being changed or addressed?
- [ ] Have you included steps or a guide to how the change may be verified and tested manually?
- [ ] Have you ensured that the full suite of tests and checks have been executed in the root metron folder via:
  ```
  mvn -q clean integration-test install && dev-utilities/build-utils/verify_licenses.sh 
  ```

- [ ] Have you written or updated unit tests and or integration tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Have you verified the basic functionality of the build by building and running locally with Vagrant full-dev environment or the equivalent?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered by building and verifying the site-book? If not then run the following commands and the verify changes via `site-book/target/site/index.html`:

  ```
  cd site-book
  mvn site
  ```

#### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
It is also recommended that [travis-ci](https://travis-ci.org) is set up for your personal repository such that your branches are built there before submitting a pull request.
