### PR TITLE
fix: disable dropdown actions for real

### DIFF
--- a/metron-interface/metron-config/src/app/sensors/sensor-parser-list/sensor-parser-list.component.scss
+++ b/metron-interface/metron-config/src/app/sensors/sensor-parser-list/sensor-parser-list.component.scss
@@ -147,3 +147,7 @@ table tr td, table tr th {
   color: white;
   font-size: 14px;
 }
+
+.dropdown .disabled {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Contributor Comments

However, the options are disabled in the dropdown menu, they accept user events like a click. I disabled the mouse events if they're disabled. 